### PR TITLE
Thesis #2: Inline pathArg validation for hot path performance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { mkdirpManual, mkdirpManualSync } from './mkdirp-manual.js'
 import { mkdirpNative, mkdirpNativeSync } from './mkdirp-native.js'
 import { MkdirpOptions, optsArg } from './opts-arg.js'
-import { pathArg } from './path-arg.js'
 import { useNative, useNativeSync } from './use-native.js'
+import { parse, resolve } from 'path'
+
+const platform = process.env.__TESTING_MKDIRP_PLATFORM__ || process.platform
 /* c8 ignore start */
 export { mkdirpManual, mkdirpManualSync } from './mkdirp-manual.js'
 export { mkdirpNative, mkdirpNativeSync } from './mkdirp-native.js'
@@ -10,7 +12,29 @@ export { useNative, useNativeSync } from './use-native.js'
 /* c8 ignore stop */
 
 export const mkdirpSync = (path: string, opts?: MkdirpOptions) => {
-  path = pathArg(path)
+  // Inline path validation to reduce function call overhead
+  if (/\0/.test(path)) {
+    throw Object.assign(
+      new TypeError('path must be a string without null bytes'),
+      {
+        path,
+        code: 'ERR_INVALID_ARG_VALUE',
+      }
+    )
+  }
+
+  path = resolve(path)
+  if (platform === 'win32') {
+    const badWinChars = /[*|"<>?:]/
+    const { root } = parse(path)
+    if (badWinChars.test(path.substring(root.length))) {
+      throw Object.assign(new Error('Illegal characters in path.'), {
+        path,
+        code: 'EINVAL',
+      })
+    }
+  }
+
   const resolved = optsArg(opts)
   return useNativeSync(resolved)
     ? mkdirpNativeSync(path, resolved)
@@ -24,7 +48,29 @@ export const native = mkdirpNative
 export const nativeSync = mkdirpNativeSync
 export const mkdirp = Object.assign(
   async (path: string, opts?: MkdirpOptions) => {
-    path = pathArg(path)
+    // Inline path validation to reduce function call overhead
+    if (/\0/.test(path)) {
+      throw Object.assign(
+        new TypeError('path must be a string without null bytes'),
+        {
+          path,
+          code: 'ERR_INVALID_ARG_VALUE',
+        }
+      )
+    }
+
+    path = resolve(path)
+    if (platform === 'win32') {
+      const badWinChars = /[*|"<>?:]/
+      const { root } = parse(path)
+      if (badWinChars.test(path.substring(root.length))) {
+        throw Object.assign(new Error('Illegal characters in path.'), {
+          path,
+          code: 'EINVAL',
+        })
+      }
+    }
+
     const resolved = optsArg(opts)
     return useNative(resolved)
       ? mkdirpNative(path, resolved)


### PR DESCRIPTION
References #2

Self-reported metric: 6764.9500
Baseline: 6326.4700
Summary: Inlined pathArg validation directly into mkdirp and mkdirpSync entry points, eliminating function call overhead. The null byte check and Windows character validation are now performed inline, enabling better JIT optimization. Benchmark shows ~6.9% improvement (6326.47 -> 6764.95 ops/sec).